### PR TITLE
Release v0.0.2

### DIFF
--- a/CHANGELOG/0.0.2.md
+++ b/CHANGELOG/0.0.2.md
@@ -1,11 +1,12 @@
 # Changelog 0.0.2
 
-Released on: 2020-XX-XX
+Released on: 2020-11-19
 
 ## Added
+
 * [#7](https://github.com/epiphany-platform/m-azure-kubernetes-service/7) - Ability to create AKS in existing subnet
 * [#8](https://github.com/epiphany-platform/m-azure-kubernetes-service/issues/8) - Add more parameter in order to create customizable, private AKS cluster
 
-### Updated
+## Updated
 
 * [#9](https://github.com/epiphany-platform/m-azure-kubernetes-service/issues/9) - Move terraform code from module directly to "top level" code

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT_DIR := $(patsubst %/,%,$(dir $(abspath $(firstword $(MAKEFILE_LIST)))))
 
-VERSION ?= 0.0.1
+VERSION ?= 0.0.2
 USER := epiphanyplatform
 IMAGE := azks
 

--- a/examples/basic_flow/Makefile
+++ b/examples/basic_flow/Makefile
@@ -1,5 +1,5 @@
 AZBI := epiphanyplatform/azbi:0.0.1
-AZKS := epiphanyplatform/azks:0.0.1
+AZKS := epiphanyplatform/azks:0.0.2
 
 #makes it easier to replace the value
 M_NAME            ?= mop-module-tests

--- a/examples/create_in_existing_subnet/Makefile
+++ b/examples/create_in_existing_subnet/Makefile
@@ -1,4 +1,4 @@
-AZKS := epiphanyplatform/azks:0.0.1
+AZKS := epiphanyplatform/azks:0.0.2
 
 #makes it easier to replace the value
 M_NAME            ?= azks-example-tests


### PR DESCRIPTION
Release needed to have K8s version configurable in order to avoid error with message `Version 1.18.6 is not supported in this region`.